### PR TITLE
Add Discord webhook for staging notifications

### DIFF
--- a/.github/workflows/eas-build.yml
+++ b/.github/workflows/eas-build.yml
@@ -52,14 +52,14 @@ jobs:
             echo "build_url=$BUILD_URL" >> $GITHUB_OUTPUT
 
       - name: Send notification to Discord
-        if: ${{ env.DISCORD_WEBHOOK_URL != '' }}
+        if: ${{ env.DISCORD_WEBHOOK_STAGING_URL != '' }}
         env:
-          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          DISCORD_WEBHOOK_STAGING_URL: ${{ secrets.DISCORD_WEBHOOK_STAGING_URL }}
         run: |
           curl -H "Content-Type: application/json" \
           -X POST \
           -d "{\"content\": \"🚀 Nouveau build Android (staging) disponible : ${{ steps.eas-build.outputs.build_url }}\"}" \
-          $DISCORD_WEBHOOK_URL
+          $DISCORD_WEBHOOK_STAGING_URL
 
       - name: Comment PR with build link and QR Code
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
Introduce a new environment variable for the Discord webhook URL specifically for staging builds, enhancing the CI process with notifications.