### PR TITLE
Update Android test build job and generate QR code

### DIFF
--- a/.github/workflows/eas-build.yml
+++ b/.github/workflows/eas-build.yml
@@ -62,7 +62,6 @@ jobs:
           $DISCORD_WEBHOOK_STAGING_URL
 
       - name: Comment PR with build link and QR Code
-        if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/eas-build.yml
+++ b/.github/workflows/eas-build.yml
@@ -10,7 +10,7 @@ on:
       - staging
 
 jobs:
-  build-test:
+  android-test-build:
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Change the job name for the Android test build and add functionality to generate a QR code for the build link.