### PR TITLE
Fix comment PR and generate QR code for pull requests

### DIFF
--- a/.github/workflows/eas-build.yml
+++ b/.github/workflows/eas-build.yml
@@ -62,6 +62,7 @@ jobs:
           $DISCORD_WEBHOOK_STAGING_URL
 
       - name: Comment PR with build link and QR Code
+        if: ${{ github.event_name == 'pull_request' }}
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Ensure the build link and QR code are only commented on pull request events.