### PR TITLE
Add CLI script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "lint": "expo lint",
     "lint:fix": "expo lint --fix",
     "storybook-generate": "sb-rn-get-stories",
+    "cli": "node scripts/cli.mjs",
     "prepare": "husky"
   },
   "dependencies": {


### PR DESCRIPTION
Include a CLI script in the package.json to enhance command-line functionality.